### PR TITLE
Add pad_token_id to generate_kwargs.

### DIFF
--- a/app.py
+++ b/app.py
@@ -146,6 +146,7 @@ def chat_llama3_8b(message: str,
         do_sample=True,
         temperature=temperature,
         eos_token_id=terminators,
+        pad_token_id=tokenizer.eos_token_id,
     )
     # This will enforce greedy generation (do_sample=False) when the temperature is passed 0, avoiding the crash.             
     if temperature == 0:


### PR DESCRIPTION
Eliminate the following warning by setting the `pad_token_id` to `generate_kwargs`.

> The attention mask is not set and cannot be inferred from input because pad token is same as eos token. As a consequence, you may observe unexpected behavior. Please pass your input's attention_mask` to obtain reliable results.`