### PR TITLE
Set TOKENIZERS_PARALLELISM=false.

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,3 +1,6 @@
+import os
+os.environ["TOKENIZERS_PARALLELISM"] = "false"
+
 import gradio as gr
 import os
 # import spaces


### PR DESCRIPTION
Set `TOKENIZERS_PARALLELISM=false` before loading dependencies.

This is required for my workstation, but I am not familiar under which conditions this is required.